### PR TITLE
COBLOCKS_REVIEW_URL: link only to 5 star review

### DIFF
--- a/class-coblocks.php
+++ b/class-coblocks.php
@@ -108,7 +108,7 @@ if ( ! class_exists( 'CoBlocks' ) ) :
 			$this->define( 'COBLOCKS_PLUGIN_FILE', __FILE__ );
 			$this->define( 'COBLOCKS_PLUGIN_BASE', plugin_basename( __FILE__ ) );
 			$this->define( 'COBLOCKS_SHOP_URL', 'https://coblocks.com/' );
-			$this->define( 'COBLOCKS_REVIEW_URL', 'https://wordpress.org/support/plugin/coblocks/reviews/' );
+			$this->define( 'COBLOCKS_REVIEW_URL', 'https://wordpress.org/support/plugin/coblocks/reviews/?filter=5' );
 		}
 
 		/**


### PR DESCRIPTION
You don't want your users to see bad review. Show them only 5 star review to encourage them to leave another 5 star review.