### PR TITLE
Update colors for the admin feedback notice and block icons

### DIFF
--- a/includes/admin/class-coblocks-feedback.php
+++ b/includes/admin/class-coblocks-feedback.php
@@ -176,11 +176,11 @@ class CoBlocks_Feedback {
 
 		<style>
 		.notice.coblocks-notice {
-			border-left-color: #595AFF !important;
+			border-left-color: #1e35b9 !important;
 			padding: 20px;
 		}
 		.rtl .notice.coblocks-notice {
-			border-right-color: #595AFF !important;
+			border-right-color: #1e35b9 !important;
 		}
 		.notice.notice.coblocks-notice .coblocks-notice-inner {
 			display: table;
@@ -194,7 +194,7 @@ class CoBlocks_Feedback {
 		}
 		.notice.coblocks-notice .coblocks-notice-icon {
 			color: #509ed2;
-			font-size: 50px;
+			font-size: 13px;
 			width: 60px;
 		}
 		.notice.coblocks-notice .coblocks-notice-icon img {
@@ -217,13 +217,13 @@ class CoBlocks_Feedback {
 			padding: 6px 50px;
 			height: auto;
 			line-height: 20px;
-			background: #595AFF;
-			border-color: #4848cd #4848cd #4848cd;
-			box-shadow: 0 1px 0 #4848cd;
-			text-shadow: 0 -1px 1px #4848cd, 1px 0 1px #4848cd, 0 1px 1px #4848cd, -1px 0 1px #4848cd;
+			background: #1e35b9;
+			border-color: #0d1f82 #0d1f82 #0d1f82;
+			box-shadow: 0 1px 0 #0d1f82;
+			text-shadow: 0 -1px 1px #0d1f82, 1px 0 1px #0d1f82, 0 1px 1px #0d1f82, -1px 0 1px #0d1f82;
 		}
 		.notice.coblocks-notice .coblocks-install-now .coblocks-install-button:hover {
-			background: #4a4cff;
+			background: #182b96;
 		}
 		.notice.coblocks-notice a.no-thanks {
 			display: block;
@@ -278,7 +278,7 @@ class CoBlocks_Feedback {
 					<h3><?php printf( esc_html__( 'Are you enjoying %s?', '@@textdomain' ), esc_html( $this->name ) ); ?></h3>
 					<p>
 						<?php /* translators: 1. Name, 2. Time */ ?>
-						<?php printf( esc_html__( 'You have been using %1$s for %2$s now! Mind leaving a quick review to let us know know what you think? I\'d really appreciate it!', '@@textdomain' ), esc_html( $this->name ), esc_html( $time ) ); ?>
+						<?php printf( esc_html__( 'You have been using %1$s for %2$s now. Mind leaving a review to let us know know what you think? We\'d really appreciate it!', '@@textdomain' ), esc_html( $this->name ), esc_html( $time ) ); ?>
 					</p>
 				</div>
 				<div class="coblocks-install-now">

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -10,7 +10,7 @@ const category = {
 };
 
 // Custom foreground icon color based on the CoBlocks branding
-const iconColor = '#555eff';
+const iconColor = '#1e35b9';
 
 // Register block category
 import icons from './utils/block-category';

--- a/src/common.scss
+++ b/src/common.scss
@@ -4,7 +4,7 @@
 $default-font: -apple-system, blinkmacsystemfont, "Segoe UI", roboto, oxygen-sans, ubuntu, cantarell, "Helvetica Neue", sans-serif;
 
 // CoBlocks branding color.
-$coblocks: #555eff;
+$coblocks: #1e35b9;
 
 // Colors.
 $black: rgb(41, 41, 41);


### PR DESCRIPTION
To prep for the 2.0 release. Closes #261.

Screenshot: 
<img width="1261" alt="screenshot 2019-02-21 17 58 37" src="https://user-images.githubusercontent.com/1813435/53207655-537c4b80-3602-11e9-9c2b-ecc43f8000e7.png">
