### PR TITLE
Tweak UI for the Hero block CSS grid toolbar control

### DIFF
--- a/src/components/grid-control/index.js
+++ b/src/components/grid-control/index.js
@@ -18,7 +18,7 @@ const { dispatch, select } = wp.data;
 const { Component, Fragment } = wp.element;
 const { ButtonGroup, Button, Tooltip, ToggleControl } = wp.components;
 
-class CSSGridControl  extends Component {
+class CSSGridControl extends Component {
 
 	constructor( props ) {
 		super( ...arguments );
@@ -133,10 +133,10 @@ class CSSGridControl  extends Component {
 			<Fragment>
 				<div className={ classes }>
 					<label className="components-base-control__label" >{ __( 'Layout' ) }</label>
-					<ButtonGroup aria-label={ __( 'Select Style' ) }>
+					<ButtonGroup aria-label={ __( 'Select Layout' ) }>
 					{ map( layoutOptions, ( { label, value, icon } ) => {
 						 if( tooltip ){
-						 	return ( 
+						 	return (
 						 		<Tooltip text={ label }>
 									<div className={ ( value == layout ) ? 'is-selected' : null }>
 										<Button
@@ -150,7 +150,7 @@ class CSSGridControl  extends Component {
 										>
 										</Button>
 									</div>
-								</Tooltip> 
+								</Tooltip>
 							)
 						 }else{
 						 	return(
@@ -171,7 +171,6 @@ class CSSGridControl  extends Component {
 					} ) }
 					</ButtonGroup>
 				</div>
-
 				<ToggleControl
 					label={ __( 'Fullscreen' ) }
 					checked={ !! fullscreen }
@@ -191,7 +190,7 @@ class CSSGridControl  extends Component {
 						}
 						setAttributes( {  fullscreen: ! fullscreen } )
 					} }
-					help={ !! fullscreen ? __( 'Displaying as the height of the viewport.' ) : __( 'Toggle to enable fullscreen mode.' ) }
+					help={ !! fullscreen ? __( 'Fullscreen mode is enabled.' ) : __( 'Toggle to enable fullscreen mode.' ) }
 				/>
 			</Fragment>
 		);

--- a/src/components/grid-control/styles/editor.scss
+++ b/src/components/grid-control/styles/editor.scss
@@ -1,13 +1,23 @@
-// Style the clickable areas for the column/layout placeholder.
 .components-coblocks-grid-dropdown {
-	.components-coblocks-css-grid-selector{
+	padding: 16px !important;
+
+	.components-coblocks-css-grid-selector {
 		width: 100%;
 
-		.components-base-control__label{
+		.components-button-group {
+			margin-bottom: 0;
+		}
+
+		.components-base-control__label {
 			display: none;
 		}
 	}
-	.components-base-control__help{
-		display:none;
+
+	.components-toggle-control {
+		border-top: 1px solid #e2e4e7;
+		color: #555d66;
+		margin: 16px -16px -16px;
+		padding: 18px 16px 14px;
+		width: calc(100% + 32px);
 	}
 }


### PR DESCRIPTION
Closes #348. 

<img width="721" alt="screenshot 2019-02-21 18 19 13" src="https://user-images.githubusercontent.com/1813435/53208664-94c22a80-3605-11e9-9735-7f3ac5872cf9.png">