### PR TITLE
Add new layout icon for the Hero block

### DIFF
--- a/src/blocks/hero/components/controls.js
+++ b/src/blocks/hero/components/controls.js
@@ -44,7 +44,7 @@ class Controls extends Component {
 				<BlockControls>
 				<Toolbar>
 					<CSSGridToolbar
-						icon={ icons.style }
+						icon={ icons.grid }
 						label={ __( 'Change layout' ) }
 						props={ this.props }
 					/>

--- a/src/blocks/hero/components/icons.js
+++ b/src/blocks/hero/components/icons.js
@@ -9,24 +9,10 @@ const { SVG, Path, G } = wp.components;
 const icons = {};
 
 icons.hero =
-<SVG className="dashicon components-coblocks-svg" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m16 0h-14c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-14c0-1.1-.9-2-2-2zm0 16h-14v-3h14z" transform="translate(3 3)"/></SVG>
+<SVG className="dashicon components-coblocks-svg" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><Path d="m16 0h-14c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-14c0-1.1-.9-2-2-2zm0 16h-14v-3h14z" transform="translate(3 3)"/></SVG>
 
-icons.style =
-<SVG height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-	<Path d="m9 0c-4.97 0-9 4.03-9 9s4.03 9 9 9c.83 0 1.5-.67 1.5-1.5 0-.39-.15-.74-.39-1.01-.23-.26-.38-.61-.38-.99 0-.83.67-1.5 1.5-1.5h1.77c2.76 0 5-2.24 5-5 0-4.42-4.03-8-9-8zm-5.5 9c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm3-4c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm5 0c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm3 4c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z" transform="translate(3 3)"/>
-</SVG>;
-
-icons.colOne =
-<svg height="28" viewBox="0 0 40 28" width="40" xmlns="http://www.w3.org/2000/svg"><path d="m38.0833333 0h-36.16666663c-1.05416667 0-1.91666667.9-1.91666667 2v24c0 1.1.8625 2 1.91666667 2h36.16666663c1.0541667 0 1.9166667-.9 1.9166667-2v-24c0-1.1-.8625-2-1.9166667-2zm0 26h-36.16666663v-24h36.16666663zm-34.0833333-22h14v7h-14z"/></svg>
-icons.colTwo =
-<svg height="28" viewBox="0 0 40 28" width="40" xmlns="http://www.w3.org/2000/svg"><path d="m38.0833333 0h-36.16666663c-1.05416667 0-1.91666667.9-1.91666667 2v24c0 1.1.8625 2 1.91666667 2h36.16666663c1.0541667 0 1.9166667-.9 1.9166667-2v-24c0-1.1-.8625-2-1.9166667-2zm0 26h-36.16666663v-24h36.16666663zm-22.5833333-22h9v2h-9zm-1 8.0233154h5v2h-5zm6 0h5v2h-5zm-7.5-4.0233154h14v3h-14z"/></svg>
-
-icons.colThree =
-<svg height="28" viewBox="0 0 40 28" width="40" xmlns="http://www.w3.org/2000/svg"><path d="m38.0833333 0h-36.16666663c-1.05416667 0-1.91666667.9-1.91666667 2v24c0 1.1.8625 2 1.91666667 2h36.16666663c1.0541667 0 1.9166667-.9 1.9166667-2v-24c0-1.1-.8625-2-1.9166667-2zm0 26h-36.16666663v-24h36.16666663zm-11.0833333-22h9v2h-9zm-2 9h5v2h-5zm6 0h5v2h-5zm-9-5h14v3h-14z"/></svg>
-
-icons.colFour =
-<svg className="dashicon" height="26" viewBox="0 0 50 26" width="50" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="m48.0833333 0h-46.16666663c-1.05416667 0-1.91666667.9-1.91666667 2v22c0 1.1.8625 2 1.91666667 2h46.16666663c1.0541667 0 1.9166667-.9 1.9166667-2v-22c0-1.1-.8625-2-1.9166667-2zm0 24h-46.16666663v-22h46.16666663z" fill-rule="nonzero"/><path d="m12 2h2v22h-2z"/><path d="m24 2h2v22h-2z"/><path d="m36 2h2v22h-2z"/></g></svg>
-
+icons.grid =
+<svg height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg"><g transform="matrix(-1 0 0 1 18 2)"><path d="m12 7h3.9566119v-6h-3.9566119z"/><path d="m6 7h4v-6h-4z"/><path d="m0 7h3.95661186v-6h-3.95661186z"/><path d="m.02169407 15h3.95661186v-6h-3.95661186z"/><path d="m6.02169407 15h4.00000003v-6h-4.00000003z"/><path d="m12.0216941 15h3.9566118v-6h-3.9566118z"/></g></svg>
 
 export default icons;
 

--- a/src/blocks/hero/components/icons.js
+++ b/src/blocks/hero/components/icons.js
@@ -12,7 +12,7 @@ icons.hero =
 <SVG className="dashicon components-coblocks-svg" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><Path d="m16 0h-14c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-14c0-1.1-.9-2-2-2zm0 16h-14v-3h14z" transform="translate(3 3)"/></SVG>
 
 icons.grid =
-<svg height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg"><g transform="matrix(-1 0 0 1 18 2)"><path d="m12 7h3.9566119v-6h-3.9566119z"/><path d="m6 7h4v-6h-4z"/><path d="m0 7h3.95661186v-6h-3.95661186z"/><path d="m.02169407 15h3.95661186v-6h-3.95661186z"/><path d="m6.02169407 15h4.00000003v-6h-4.00000003z"/><path d="m12.0216941 15h3.9566118v-6h-3.9566118z"/></g></svg>
+<SVG height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg"><G transform="matrix(-1 0 0 1 18 2)"><Path d="m12 7h3.9566119v-6h-3.9566119z"/><Path d="m6 7h4v-6h-4z"/><Path d="m0 7h3.95661186v-6h-3.95661186z"/><Path d="m.02169407 15h3.95661186v-6h-3.95661186z"/><Path d="m6.02169407 15h4.00000003v-6h-4.00000003z"/><Path d="m12.0216941 15h3.9566118v-6h-3.9566118z"/></G></SVG>
 
 export default icons;
 

--- a/src/blocks/hero/components/inspector.js
+++ b/src/blocks/hero/components/inspector.js
@@ -84,30 +84,6 @@ class Inspector extends Component {
 			saveCoBlocksMeta,
 		} = attributes;
 
-		/**
-		 * Set layout options and padding controls for Row Blocks
-		 * This will make us of existing block instead of creating new one
-		 */
-		let layoutOptions = [
-			{ value: 'top-left', label: __( 'Top Left' ), icon: icons.colOne },
-			{ value: 'top-center', label: __( 'Top Center' ), icon: icons.colTwo },
-			{ value: 'top-right', label: __( 'Top Right' ), icon: icons.colThree },
-			{ value: 'center-left', label: __( 'Center Left' ), icon: icons.colFour },
-			{ value: 'center-center', label: __( 'Center Center' ), icon: icons.colOne },
-			{ value: 'center-right', label: __( 'Center Right' ), icon: icons.colTwo },
-			{ value: 'bottom-left', label: __( 'Bottom Left' ), icon: icons.colThree },
-			{ value: 'bottom-center', label: __( 'Bottom Center' ), icon: icons.colFour },
-			{ value: 'bottom-right', label: __( 'Bottom Right' ), icon: icons.colOne },
-		];
-
-		if( !fullscreen ){
-			layoutOptions = [
-				{ value: 'center-left', label: __( 'Center Left' ), icon: icons.colFour },
-				{ value: 'center-center', label: __( 'Center Center' ), icon: icons.colOne },
-				{ value: 'center-right', label: __( 'Center Right' ), icon: icons.colTwo },
-			];
-		}
-
 		let layoutAttributes = {};
 		//top
 		layoutAttributes[ 'top-left' ] = {


### PR DESCRIPTION
Replaces the old "style" icon for an icon that is more representative of layouts. 

Screenshot (_between the align and text align toolbars_):
<img width="685" alt="Screenshot 2019-03-18 11 27 49" src="https://user-images.githubusercontent.com/1813435/54541977-505e4c00-4971-11e9-9e97-b3e7a77e3e91.png">

Closes #388 