### PR TITLE
Use has_block() to determine whether a $post contains specific blocks

### DIFF
--- a/includes/class-coblocks-accordion-ie-support.php
+++ b/includes/class-coblocks-accordion-ie-support.php
@@ -75,23 +75,23 @@ class CoBlocks_Accordion_IE_Support {
 	 * @access public
 	 */
 	public function load_assets() {
+
 		global $post;
 
-		//load only of post ID exists
-		if( isset( $post->ID ) ){
-			$legacy_support = get_post_meta( $post->ID, '_coblocks_accordion_ie_support', true );
+		$legacy_support = get_post_meta( $post->ID, '_coblocks_accordion_ie_support', true );
 
-			if ( "'true'" === $legacy_support ) {
-				$dir = CoBlocks()->asset_source( 'js' );
+		// Determine whether a $post contains an Accordion block.
+		if ( has_block( 'coblocks/accordion' ) && "'true'" === $legacy_support ) {
 
-				wp_enqueue_script(
-					$this->_slug . '-accordion-polyfill',
-					$dir . $this->_slug . '-accordion-polyfill' . COBLOCKS_ASSET_SUFFIX . '.js',
-					array(),
-					$this->_version,
-					true
-				);
-			}
+			$dir = CoBlocks()->asset_source( 'js' );
+
+			wp_enqueue_script(
+				$this->_slug . '-accordion-polyfill',
+				$dir . $this->_slug . '-accordion-polyfill' . COBLOCKS_ASSET_SUFFIX . '.js',
+				array(),
+				$this->_version,
+				true
+			);
 		}
 	}
 }

--- a/includes/class-coblocks-google-map.php
+++ b/includes/class-coblocks-google-map.php
@@ -76,13 +76,16 @@ class CoBlocks_Block_GoogleMap {
 	 * @access public
 	 */
 	public function map_assets() {
-		global $post;
+
 		// Retrieve the Google Maps API key.
 		$key = get_option( 'coblocks_google_maps_api_key' );
+
 		// Define where the asset is loaded from.
 		$dir = CoBlocks()->asset_source( 'js' );
+
 		// Google Maps block.
-		if ( $key && ( $post && null !== $post->post_content && strpos( $post->post_content, 'wp-block-coblocks-map' ) ) ) {
+		if ( has_block( 'coblocks/map' ) && $key ) {
+
 			wp_enqueue_script(
 				$this->_slug . '-google-maps',
 				$dir . $this->_slug . '-google-maps' . COBLOCKS_ASSET_SUFFIX . '.js',
@@ -90,13 +93,15 @@ class CoBlocks_Block_GoogleMap {
 				$this->_version,
 				true
 			);
+
 			wp_enqueue_script(
 				$this->_slug . '-google-maps-api',
-				'https://maps.googleapis.com/maps/api/js?key=' . $key,
+				'https://maps.googleapis.com/maps/api/js?key=' . esc_url( $key ),
 				array( $this->_slug . '-google-maps' ),
 				$this->_version,
 				true
 			);
+
 			wp_localize_script( $this->_slug . '-google-maps', 'baAtts', array( 'url' => $this->_url ) );
 		}
 	}

--- a/includes/class-coblocks-google-map.php
+++ b/includes/class-coblocks-google-map.php
@@ -83,7 +83,7 @@ class CoBlocks_Block_GoogleMap {
 		// Define where the asset is loaded from.
 		$dir = CoBlocks()->asset_source( 'js' );
 
-		// Google Maps block.
+		// Determine whether a $post contains a Map block.
 		if ( has_block( 'coblocks/map' ) && $key ) {
 
 			wp_enqueue_script(


### PR DESCRIPTION
This PR adds support for has_block, instead of how we were originally checking for blocks. 

Closes #423. 