### PR TITLE
Rename BackgroundDropZone and tweak labels

### DIFF
--- a/src/blocks/features/components/edit.js
+++ b/src/blocks/features/components/edit.js
@@ -84,7 +84,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundImageDropZone
 				{ ...this.props }
-				label={ __( 'Add backround image' ) }
+				label={ __( 'Add as backround' ) }
 			/>
 		);
 

--- a/src/blocks/features/components/edit.js
+++ b/src/blocks/features/components/edit.js
@@ -8,7 +8,7 @@ import times from 'lodash/times';
 /**
  * Internal dependencies
  */
-import BackgroundImagePanel, { BackgroundClasses, BackgroundImageDropZone } from '../../../components/background';
+import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
 import applyWithColors from './colors';
 import Inspector from './inspector';
 import Controls from './controls';
@@ -82,7 +82,7 @@ class Edit extends Component {
 		} = attributes;
 
 		const dropZone = (
-			<BackgroundImageDropZone
+			<BackgroundDropZone
 				{ ...this.props }
 				label={ __( 'Add as backround' ) }
 			/>

--- a/src/blocks/features/feature/components/edit.js
+++ b/src/blocks/features/feature/components/edit.js
@@ -70,7 +70,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundImageDropZone
 				{ ...this.props }
-				label={ __( 'Add backround image' ) }
+				label={ __( 'Add as backround' ) }
 			/>
 		);
 

--- a/src/blocks/features/feature/components/edit.js
+++ b/src/blocks/features/feature/components/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Controls from './controls';
-import BackgroundImagePanel, { BackgroundClasses, BackgroundImageDropZone } from '../../../../components/background';
+import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../../components/background';
 import applyWithColors from './colors';
 import Inspector from './inspector';
 
@@ -68,7 +68,7 @@ class Edit extends Component {
 		} = attributes;
 
 		const dropZone = (
-			<BackgroundImageDropZone
+			<BackgroundDropZone
 				{ ...this.props }
 				label={ __( 'Add as backround' ) }
 			/>

--- a/src/blocks/hero/components/edit.js
+++ b/src/blocks/hero/components/edit.js
@@ -12,7 +12,7 @@ import { title } from '../'
 import Inspector from './inspector';
 import Controls from './controls';
 import applyWithColors from './colors';
-import BackgroundImagePanel, { BackgroundClasses, BackgroundImageDropZone } from '../../../components/background';
+import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
 
 /**
  * WordPress dependencies
@@ -102,7 +102,7 @@ class Edit extends Component {
 		} = attributes;
 
 		const dropZone = (
-			<BackgroundImageDropZone
+			<BackgroundDropZone
 				{ ...this.props }
 				label={ sprintf( __( 'Add backround to %s' ), title.toLowerCase() ) } // translators: %s: Lowercase block title
 			/>

--- a/src/blocks/hero/components/edit.js
+++ b/src/blocks/hero/components/edit.js
@@ -104,7 +104,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundImageDropZone
 				{ ...this.props }
-				label={ __( 'Drop to add as backround' ) }
+				label={ sprintf( __( 'Add backround to %s' ), title.toLowerCase() ) } // translators: %s: Lowercase block title
 			/>
 		);
 

--- a/src/blocks/hero/components/edit.js
+++ b/src/blocks/hero/components/edit.js
@@ -104,7 +104,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundImageDropZone
 				{ ...this.props }
-				label={ sprintf( __( 'Add backround image to %s' ), title.toLowerCase() ) } // translators: %s: Lowercase block title
+				label={ __( 'Drop to add as backround' ) }
 			/>
 		);
 

--- a/src/blocks/media-card/components/edit.js
+++ b/src/blocks/media-card/components/edit.js
@@ -11,7 +11,7 @@ import includes from 'lodash/includes';
 import applyWithColors from './colors';
 import Controls from './controls';
 import Inspector from './inspector';
-import BackgroundImagePanel, { BackgroundClasses, BackgroundImageDropZone } from '../../../components/background';
+import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
 import icons from './../../../utils/icons';
 import MediaContainer from './media-container';
 
@@ -176,7 +176,7 @@ class Edit extends Component {
 		} = attributes;
 
 		const dropZone = (
-			<BackgroundImageDropZone
+			<BackgroundDropZone
 				{ ...this.props }
 				label={ __( 'Add as backround' ) }
 			/>

--- a/src/blocks/media-card/components/edit.js
+++ b/src/blocks/media-card/components/edit.js
@@ -178,7 +178,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundImageDropZone
 				{ ...this.props }
-				label={ __( 'Add backround image' ) }
+				label={ __( 'Add as backround' ) }
 			/>
 		);
 

--- a/src/blocks/row/column/components/edit.js
+++ b/src/blocks/row/column/components/edit.js
@@ -11,7 +11,7 @@ import Inspector from './inspector';
 import Controls from './controls';
 import applyWithColors from './colors';
 import { title, icon } from '../'
-import BackgroundImagePanel, { BackgroundClasses, BackgroundImageDropZone } from '../../../../components/background';
+import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../../components/background';
 
 /**
  * WordPress dependencies
@@ -82,7 +82,7 @@ class Edit extends Component {
 		const nextBlockClientId = wp.data.select( 'core/editor' ).getNextBlockClientId( clientId );
 		const nextBlockClient = wp.data.select( 'core/editor' ).getBlock( nextBlockClientId );
 		const dropZone = (
-			<BackgroundImageDropZone
+			<BackgroundDropZone
 				{ ...this.props }
 				label={ sprintf( __( 'Add backround to %s' ), title.toLowerCase() ) } // translators: %s: Lowercase block title
 			/>

--- a/src/blocks/row/column/components/edit.js
+++ b/src/blocks/row/column/components/edit.js
@@ -84,10 +84,10 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundImageDropZone
 				{ ...this.props }
-				label={ sprintf( __( 'Add backround image to %s' ), title.toLowerCase() ) } // translators: %s: Lowercase block title
+				label={ sprintf( __( 'Add backround to %s' ), title.toLowerCase() ) } // translators: %s: Lowercase block title
 			/>
 		);
-		
+
 		const classes = classnames(
 			'wp-block-coblocks-column', {
 				[ `coblocks-column-${ coblocks.id }` ] : coblocks && ( typeof coblocks.id != 'undefined' ),

--- a/src/blocks/row/components/edit.js
+++ b/src/blocks/row/components/edit.js
@@ -15,7 +15,7 @@ import Controls from './controls';
 import applyWithColors from './colors';
 import rowIcons from './icons';
 import { title, icon } from '../'
-import BackgroundImagePanel, { BackgroundClasses, BackgroundImageDropZone } from '../../../components/background';
+import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
 
 /**
  * WordPress dependencies
@@ -171,7 +171,7 @@ class Edit extends Component {
 		} = attributes;
 
 		const dropZone = (
-			<BackgroundImageDropZone
+			<BackgroundDropZone
 				{ ...this.props }
 				label={ sprintf( __( 'Add backround to %s' ), title.toLowerCase() ) } // translators: %s: Lowercase block title
 			/>

--- a/src/blocks/row/components/edit.js
+++ b/src/blocks/row/components/edit.js
@@ -173,7 +173,7 @@ class Edit extends Component {
 		const dropZone = (
 			<BackgroundImageDropZone
 				{ ...this.props }
-				label={ sprintf( __( 'Add backround image to %s' ), title.toLowerCase() ) } // translators: %s: Lowercase block title
+				label={ sprintf( __( 'Add backround to %s' ), title.toLowerCase() ) } // translators: %s: Lowercase block title
 			/>
 		);
 

--- a/src/components/background/dropzone.js
+++ b/src/components/background/dropzone.js
@@ -34,7 +34,7 @@ class BackgroundImageDropZone extends Component {
 		if ( media && media.url && media.mime_type ) {
 
 			var mediaType = 'image';
-			
+
 			if( media.mime_type.includes( 'video' ) ){
 				mediaType = 'video';
 			}

--- a/src/components/background/dropzone.js
+++ b/src/components/background/dropzone.js
@@ -14,7 +14,7 @@ const { DropZone } = wp.components;
 /**
  * Gallery Drop Zone Component
  */
-class BackgroundImageDropZone extends Component {
+class BackgroundDropZone extends Component {
 
 	constructor() {
 		super( ...arguments );
@@ -70,4 +70,4 @@ class BackgroundImageDropZone extends Component {
 	}
 }
 
-export default BackgroundImageDropZone;
+export default BackgroundDropZone;

--- a/src/components/background/index.js
+++ b/src/components/background/index.js
@@ -6,7 +6,7 @@ import './styles/editor.scss';
 import BackgroundAttributes from './attributes';
 import BackgroundClasses from './classes';
 import BackgroundImageToolbarControls from './controls';
-import BackgroundImageDropZone from './dropzone';
+import BackgroundDropZone from './dropzone';
 import BackgroundImageTransforms from './transforms';
 
 /**
@@ -29,7 +29,7 @@ export {
 	BackgroundAttributes,
 	BackgroundClasses,
 	BackgroundImageToolbarControls,
-	BackgroundImageDropZone,
+	BackgroundDropZone,
 	BackgroundImageTransforms,
 };
 


### PR DESCRIPTION
Renames `BackgroundImageDropZone` to `BackgroundDropZone` and provides better labels for the drop zones, which used to reference image-only backgrounds. Closes #429 