### PR TITLE
Update background component names

### DIFF
--- a/src/blocks/features/components/controls.js
+++ b/src/blocks/features/components/controls.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import icons from './../../../utils/icons';
-import BackgroundImagePanel, { BackgroundImageToolbarControls } from '../../../components/background';
+import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../components/background';
 
 /**
  * WordPress dependencies

--- a/src/blocks/features/components/controls.js
+++ b/src/blocks/features/components/controls.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import icons from './../../../utils/icons';
-import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../components/background';
+import BackgroundPanel, { BackgroundControls } from '../../../components/background';
 
 /**
  * WordPress dependencies
@@ -37,7 +37,7 @@ class Controls extends Component {
 						value={ contentAlign }
 						onChange={ ( nextContentAlign ) => setAttributes( { contentAlign: nextContentAlign } ) }
 					/>
-					{ BackgroundImageToolbarControls( this.props ) }
+					{ BackgroundControls( this.props ) }
 				</BlockControls>
 			</Fragment>
 		);

--- a/src/blocks/features/components/edit.js
+++ b/src/blocks/features/components/edit.js
@@ -8,7 +8,7 @@ import times from 'lodash/times';
 /**
  * Internal dependencies
  */
-import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
+import BackgroundPanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
 import applyWithColors from './colors';
 import Inspector from './inspector';
 import Controls from './controls';

--- a/src/blocks/features/components/inspector.js
+++ b/src/blocks/features/components/inspector.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import applyWithColors from './colors';
-import BackgroundImagePanel from '../../../components/background';
+import BackgroundPanel from '../../../components/background';
 import DimensionsControl from '../../../components/dimensions-control/';
 
 /**
@@ -206,7 +206,7 @@ class Inspector extends Component {
 						] }
 					>
 					</PanelColorSettings>
-					{ BackgroundImagePanel( this.props, { overlay: true } ) }
+					{ BackgroundPanel( this.props, { overlay: true } ) }
 				</InspectorControls>
 			</Fragment>
 		);

--- a/src/blocks/features/feature/components/controls.js
+++ b/src/blocks/features/feature/components/controls.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import BackgroundImagePanel, { BackgroundImageToolbarControls } from '../../../../components/background';
+import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../../components/background';
 
 /**
  * WordPress dependencies

--- a/src/blocks/features/feature/components/controls.js
+++ b/src/blocks/features/feature/components/controls.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../../components/background';
+import BackgroundPanel, { BackgroundControls } from '../../../../components/background';
 
 /**
  * WordPress dependencies
@@ -34,7 +34,7 @@ class Controls extends Component {
 						value={ contentAlign }
 						onChange={ ( nextContentAlign ) => setAttributes( { contentAlign: nextContentAlign } ) }
 					/>
-					{ BackgroundImageToolbarControls( this.props ) }
+					{ BackgroundControls( this.props ) }
 				</BlockControls>
 			</Fragment>
 		);

--- a/src/blocks/features/feature/components/edit.js
+++ b/src/blocks/features/feature/components/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Controls from './controls';
-import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../../components/background';
+import BackgroundPanel, { BackgroundClasses, BackgroundDropZone } from '../../../../components/background';
 import applyWithColors from './colors';
 import Inspector from './inspector';
 

--- a/src/blocks/features/feature/components/inspector.js
+++ b/src/blocks/features/feature/components/inspector.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import applyWithColors from './colors';
-import BackgroundImagePanel from '../../../../components/background';
+import BackgroundPanel from '../../../../components/background';
 import DimensionsControl from '../../../../components/dimensions-control/';
 
 /**
@@ -126,7 +126,7 @@ class Inspector extends Component {
 						] }
 					>
 					</PanelColorSettings>
-					{ BackgroundImagePanel( this.props, { overlay: true } ) }
+					{ BackgroundPanel( this.props, { overlay: true } ) }
 				</InspectorControls>
 			</Fragment>
 		);

--- a/src/blocks/features/feature/index.js
+++ b/src/blocks/features/feature/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses } from '../../../components/background';
+import BackgroundPanel, { BackgroundAttributes, BackgroundClasses } from '../../../components/background';
 import DimensionsAttributes from '../../../components/dimensions-control/attributes';
 import Edit from './components/edit';
 import icons from './components/icons';

--- a/src/blocks/features/index.js
+++ b/src/blocks/features/index.js
@@ -9,7 +9,7 @@ import map from 'lodash/map';
  */
 import './styles/style.scss';
 import './styles/editor.scss';
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses } from '../../components/background';
+import BackgroundPanel, { BackgroundAttributes, BackgroundClasses } from '../../components/background';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 import Edit from './components/edit';
 import icons from './components/icons';

--- a/src/blocks/hero/components/controls.js
+++ b/src/blocks/hero/components/controls.js
@@ -8,7 +8,7 @@ import map from 'lodash/map';
  */
 import icons from './icons';
 import { layoutOptions } from './layouts'
-import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../components/background';
+import BackgroundPanel, { BackgroundControls } from '../../../components/background';
 import VisualDropdown from '../../../components/visual-dropdown/';
 import CSSGridToolbar from '../../../components/grid-control/toolbar';
 
@@ -53,7 +53,7 @@ class Controls extends Component {
 					value={ contentAlign }
 					onChange={ ( nextContentAlign ) => setAttributes( { contentAlign: nextContentAlign } ) }
 				/>
-					{ BackgroundImageToolbarControls( this.props ) }
+					{ BackgroundControls( this.props ) }
 				</BlockControls>
 			</Fragment>
 		);

--- a/src/blocks/hero/components/controls.js
+++ b/src/blocks/hero/components/controls.js
@@ -8,7 +8,7 @@ import map from 'lodash/map';
  */
 import icons from './icons';
 import { layoutOptions } from './layouts'
-import BackgroundImagePanel, { BackgroundImageToolbarControls } from '../../../components/background';
+import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../components/background';
 import VisualDropdown from '../../../components/visual-dropdown/';
 import CSSGridToolbar from '../../../components/grid-control/toolbar';
 

--- a/src/blocks/hero/components/edit.js
+++ b/src/blocks/hero/components/edit.js
@@ -12,7 +12,7 @@ import { title } from '../'
 import Inspector from './inspector';
 import Controls from './controls';
 import applyWithColors from './colors';
-import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
+import BackgroundPanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
 
 /**
  * WordPress dependencies

--- a/src/blocks/hero/components/inspector.js
+++ b/src/blocks/hero/components/inspector.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  */
 import icons from './icons';
 import applyWithColors from './colors';
-import BackgroundImagePanel from '../../../components/background';
+import BackgroundPanel from '../../../components/background';
 import DimensionsControl from '../../../components/dimensions-control/';
 import CSSGridControl from '../../../components/grid-control/';
 
@@ -204,7 +204,7 @@ class Inspector extends Component {
 						] }
 					>
 					</PanelColorSettings>
-					{ BackgroundImagePanel( this.props, { overlay: true } ) }
+					{ BackgroundPanel( this.props, { overlay: true } ) }
 				</InspectorControls>
 			</Fragment>
 		);

--- a/src/blocks/hero/index.js
+++ b/src/blocks/hero/index.js
@@ -10,7 +10,7 @@ import './styles/style.scss';
 import './styles/editor.scss';
 import icons from './components/icons';
 import Edit from './components/edit';
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../components/background';
+import BackgroundPanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../components/background';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 import CSSGridAttributes from '../../components/grid-control/attributes';
 

--- a/src/blocks/hero/index.js
+++ b/src/blocks/hero/index.js
@@ -10,7 +10,7 @@ import './styles/style.scss';
 import './styles/editor.scss';
 import icons from './components/icons';
 import Edit from './components/edit';
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundImageTransforms } from '../../components/background';
+import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../components/background';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 import CSSGridAttributes from '../../components/grid-control/attributes';
 

--- a/src/blocks/media-card/components/controls.js
+++ b/src/blocks/media-card/components/controls.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import BackgroundImagePanel, { BackgroundImageToolbarControls } from '../../../components/background';
+import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../components/background';
 import icons from './icons';
 
 /**

--- a/src/blocks/media-card/components/controls.js
+++ b/src/blocks/media-card/components/controls.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../components/background';
+import BackgroundPanel, { BackgroundControls } from '../../../components/background';
 import icons from './icons';
 
 /**
@@ -47,7 +47,7 @@ class Controls extends Component {
 					<Toolbar
 						controls={ toolbarControls }
 					/>
-					{ BackgroundImageToolbarControls( this.props ) }
+					{ BackgroundControls( this.props ) }
 				</BlockControls>
 			</Fragment>
 		);

--- a/src/blocks/media-card/components/edit.js
+++ b/src/blocks/media-card/components/edit.js
@@ -11,7 +11,7 @@ import includes from 'lodash/includes';
 import applyWithColors from './colors';
 import Controls from './controls';
 import Inspector from './inspector';
-import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
+import BackgroundPanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
 import icons from './../../../utils/icons';
 import MediaContainer from './media-container';
 

--- a/src/blocks/media-card/components/inspector.js
+++ b/src/blocks/media-card/components/inspector.js
@@ -3,7 +3,7 @@
  */
 import applyWithColors from './colors';
 import icons from './../../../utils/icons';
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses } from '../../../components/background';
+import BackgroundPanel, { BackgroundAttributes, BackgroundClasses } from '../../../components/background';
 import DimensionsControl from '../../../components/dimensions-control/';
 
 /**
@@ -140,7 +140,7 @@ class Inspector extends Component {
 						] }
 					>
 					</PanelColorSettings>
-					{ BackgroundImagePanel( this.props, { overlay: true } ) }
+					{ BackgroundPanel( this.props, { overlay: true } ) }
 				</InspectorControls>
 			</Fragment>
 		);

--- a/src/blocks/media-card/index.js
+++ b/src/blocks/media-card/index.js
@@ -13,7 +13,7 @@ import './styles/editor.scss';
 import icons from './components/icons';
 import brandAssets from '../../utils/brand-assets';
 import Edit from './components/edit';
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../components/background';
+import BackgroundPanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../components/background';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 
 /**

--- a/src/blocks/media-card/index.js
+++ b/src/blocks/media-card/index.js
@@ -13,7 +13,7 @@ import './styles/editor.scss';
 import icons from './components/icons';
 import brandAssets from '../../utils/brand-assets';
 import Edit from './components/edit';
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundImageTransforms } from '../../components/background';
+import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../components/background';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 
 /**

--- a/src/blocks/row/column/components/controls.js
+++ b/src/blocks/row/column/components/controls.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import BackgroundImagePanel, { BackgroundImageToolbarControls } from '../../../../components/background';
+import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../../components/background';
 
 /**
  * WordPress dependencies

--- a/src/blocks/row/column/components/controls.js
+++ b/src/blocks/row/column/components/controls.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../../components/background';
+import BackgroundPanel, { BackgroundControls } from '../../../../components/background';
 
 /**
  * WordPress dependencies
@@ -34,7 +34,7 @@ class Controls extends Component {
 						value={ contentAlign }
 						onChange={ ( nextContentAlign ) => setAttributes( { contentAlign: nextContentAlign } ) }
 					/>
-					{ BackgroundImageToolbarControls( this.props ) }
+					{ BackgroundControls( this.props ) }
 				</BlockControls>
 			</Fragment>
 		);

--- a/src/blocks/row/column/components/edit.js
+++ b/src/blocks/row/column/components/edit.js
@@ -11,7 +11,7 @@ import Inspector from './inspector';
 import Controls from './controls';
 import applyWithColors from './colors';
 import { title, icon } from '../'
-import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../../components/background';
+import BackgroundPanel, { BackgroundClasses, BackgroundDropZone } from '../../../../components/background';
 
 /**
  * WordPress dependencies

--- a/src/blocks/row/column/components/inspector.js
+++ b/src/blocks/row/column/components/inspector.js
@@ -7,7 +7,7 @@ import map from 'lodash/map';
  * Internal dependencies
  */
 import applyWithColors from './colors';
-import BackgroundImagePanel from '../../../../components/background';
+import BackgroundPanel from '../../../../components/background';
 import DimensionsControl from '../../../../components/dimensions-control/';
 
 /**
@@ -155,7 +155,7 @@ class Inspector extends Component {
 						] }
 					>
 					</PanelColorSettings>
-					{ BackgroundImagePanel( this.props, { overlay: true } ) }
+					{ BackgroundPanel( this.props, { overlay: true } ) }
 				</InspectorControls>
 			</Fragment>
 		);

--- a/src/blocks/row/column/index.js
+++ b/src/blocks/row/column/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import Edit from './components/edit';
 import icons from './../../../utils/icons';
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../../components/background';
+import BackgroundPanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../../components/background';
 import DimensionsAttributes from '../../../components/dimensions-control/attributes';
 
 /**

--- a/src/blocks/row/column/index.js
+++ b/src/blocks/row/column/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import Edit from './components/edit';
 import icons from './../../../utils/icons';
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundImageTransforms } from '../../../components/background';
+import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../../components/background';
 import DimensionsAttributes from '../../../components/dimensions-control/attributes';
 
 /**

--- a/src/blocks/row/components/controls.js
+++ b/src/blocks/row/components/controls.js
@@ -8,7 +8,7 @@ import map from 'lodash/map';
  */
 import { layoutOptions } from './layouts'
 import rowIcons from './icons';
-import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../components/background';
+import BackgroundPanel, { BackgroundControls } from '../../../components/background';
 import VisualDropdown from '../../../components/visual-dropdown/';
 
 /**
@@ -100,7 +100,7 @@ class Controls extends Component {
 						</Toolbar>
 					}
 					{ layout &&
-						BackgroundImageToolbarControls( this.props )
+						BackgroundControls( this.props )
 					}
 				</BlockControls>
 			</Fragment>

--- a/src/blocks/row/components/controls.js
+++ b/src/blocks/row/components/controls.js
@@ -8,7 +8,7 @@ import map from 'lodash/map';
  */
 import { layoutOptions } from './layouts'
 import rowIcons from './icons';
-import BackgroundImagePanel, { BackgroundImageToolbarControls } from '../../../components/background';
+import BackgroundPanel, { BackgroundImageToolbarControls } from '../../../components/background';
 import VisualDropdown from '../../../components/visual-dropdown/';
 
 /**

--- a/src/blocks/row/components/edit.js
+++ b/src/blocks/row/components/edit.js
@@ -15,7 +15,7 @@ import Controls from './controls';
 import applyWithColors from './colors';
 import rowIcons from './icons';
 import { title, icon } from '../'
-import BackgroundImagePanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
+import BackgroundPanel, { BackgroundClasses, BackgroundDropZone } from '../../../components/background';
 
 /**
  * WordPress dependencies

--- a/src/blocks/row/components/inspector.js
+++ b/src/blocks/row/components/inspector.js
@@ -9,7 +9,7 @@ import map from 'lodash/map';
 import { layoutOptions } from './layouts'
 import rowIcons from './icons';
 import applyWithColors from './colors';
-import BackgroundImagePanel from '../../../components/background';
+import BackgroundPanel from '../../../components/background';
 import DimensionsControl from '../../../components/dimensions-control/';
 
 /**
@@ -250,7 +250,7 @@ class Inspector extends Component {
 										] }
 									>
 									</PanelColorSettings>
-									{ BackgroundImagePanel( this.props, { overlay: true } ) }
+									{ BackgroundPanel( this.props, { overlay: true } ) }
 								</Fragment>
 							}
 						</Fragment>

--- a/src/blocks/row/index.js
+++ b/src/blocks/row/index.js
@@ -11,7 +11,7 @@ import './styles/editor.scss';
 import './styles/style.scss';
 import Edit from './components/edit';
 import icons from './../../utils/icons';
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundImageTransforms } from '../../components/background';
+import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../components/background';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 
 /**

--- a/src/blocks/row/index.js
+++ b/src/blocks/row/index.js
@@ -11,7 +11,7 @@ import './styles/editor.scss';
 import './styles/style.scss';
 import Edit from './components/edit';
 import icons from './../../utils/icons';
-import BackgroundImagePanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../components/background';
+import BackgroundPanel, { BackgroundAttributes, BackgroundClasses, BackgroundTransforms } from '../../components/background';
 import DimensionsAttributes from '../../components/dimensions-control/attributes';
 
 /**

--- a/src/components/background/controls.js
+++ b/src/components/background/controls.js
@@ -22,7 +22,7 @@ const { Toolbar, IconButton, Popover, MenuItem } = wp.components;
 /**
  * Background image block toolbar controls
  */
-function BackgroundImageToolbarControls( props, options ) {
+function BackgroundControls( props, options ) {
 
 	const {
 		attributes,
@@ -109,4 +109,4 @@ function BackgroundImageToolbarControls( props, options ) {
 	);
 }
 
-export default BackgroundImageToolbarControls;
+export default BackgroundControls;

--- a/src/components/background/index.js
+++ b/src/components/background/index.js
@@ -7,7 +7,7 @@ import BackgroundAttributes from './attributes';
 import BackgroundClasses from './classes';
 import BackgroundImageToolbarControls from './controls';
 import BackgroundDropZone from './dropzone';
-import BackgroundImageTransforms from './transforms';
+import BackgroundTransforms from './transforms';
 
 /**
  * WordPress dependencies
@@ -30,7 +30,7 @@ export {
 	BackgroundClasses,
 	BackgroundImageToolbarControls,
 	BackgroundDropZone,
-	BackgroundImageTransforms,
+	BackgroundTransforms,
 };
 
 /**

--- a/src/components/background/index.js
+++ b/src/components/background/index.js
@@ -5,7 +5,7 @@ import './styles/style.scss';
 import './styles/editor.scss';
 import BackgroundAttributes from './attributes';
 import BackgroundClasses from './classes';
-import BackgroundImageToolbarControls from './controls';
+import BackgroundControls from './controls';
 import BackgroundDropZone from './dropzone';
 import BackgroundTransforms from './transforms';
 
@@ -28,7 +28,7 @@ export const BLOCKS_WITH_AUTOPADDING = [ 'coblocks/row', 'coblocks/column', 'cob
 export {
 	BackgroundAttributes,
 	BackgroundClasses,
-	BackgroundImageToolbarControls,
+	BackgroundControls,
 	BackgroundDropZone,
 	BackgroundTransforms,
 };

--- a/src/components/background/index.js
+++ b/src/components/background/index.js
@@ -36,7 +36,7 @@ export {
 /**
  * Background Options Component
  */
-function BackgroundImagePanel( props, options ) {
+function BackgroundPanel( props, options ) {
 
 	const {
 		attributes,
@@ -224,4 +224,4 @@ function BackgroundImagePanel( props, options ) {
 	}
 }
 
-export default BackgroundImagePanel;
+export default BackgroundPanel;

--- a/src/components/background/transforms.js
+++ b/src/components/background/transforms.js
@@ -2,7 +2,7 @@
  * Set the attributes for the Background transformations
  * @type {Object}
  */
-function BackgroundImageTransforms( props ) {
+function BackgroundTransforms( props ) {
 
 	const transforms = {
 		backgroundColor: props.backgroundColor,
@@ -18,4 +18,4 @@ function BackgroundImageTransforms( props ) {
 	return transforms;
 }
 
-export default BackgroundImageTransforms;
+export default BackgroundTransforms;


### PR DESCRIPTION
This PR tweaks a few component names so that they are not "image" specific, now that we support background videos globally. 